### PR TITLE
Update pragma to ^0.4.24

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
-  compileCommand: '../node_modules/.bin/darq-truffle compile --network coverage',
-  testCommand: '../node_modules/.bin/darq-truffle test --network coverage',
+  compileCommand: '../node_modules/.bin/truffle compile --network coverage',
+  testCommand: '../node_modules/.bin/truffle test --network coverage',
   testrpcOptions: '--noVMErrorsOnRPCResponse --port 8555',
   skipFiles: ['mocks']
 }

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 
 contract Authority {

--- a/contracts/IndexedOrderedSetLib.sol
+++ b/contracts/IndexedOrderedSetLib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 /// @title Library implementing an array type which allows O(1) lookups on values.
 /// @author Piper Merriam <pipermerriam@gmail.com>

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.4.24;
 
 contract Migrations {
   address public owner;

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 import {SemVersionLib} from "./SemVersionLib.sol";
 import {IndexedOrderedSetLib} from "./IndexedOrderedSetLib.sol";

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 
 import {PackageDB} from "./PackageDB.sol";

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 
 import {AuthorizedInterface} from "./Authority.sol";

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 import {SemVersionLib} from "./SemVersionLib.sol";
 import {IndexedOrderedSetLib} from "./IndexedOrderedSetLib.sol";

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 import {PackageDB} from "./PackageDB.sol";
 import {ReleaseDB} from "./ReleaseDB.sol";

--- a/contracts/SemVersionLib.sol
+++ b/contracts/SemVersionLib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 /// @title Library which implements a semver datatype and comparisons.
 /// @author Piper Merriam <pipermerriam@gmail.com>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ganache-cli": "^6.1.0",
     "shelljs": "^0.8.1",
     "solidity-coverage": "^0.5.0",
-    "solium": "^1.1.7"
+    "solium": "^1.1.7",
+    "truffle": "^5.0.0-next.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "coveralls": "^3.0.0",
     "darq-truffle": "4.1.4-next.7",
     "eth-gas-reporter": "^0.1.7",
-    "ganache-cli": "^6.1.0",
+    "ganache-cli": "6.1.0",
     "shelljs": "^0.8.1",
     "solidity-coverage": "^0.5.0",
     "solium": "^1.1.7",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -69,4 +69,4 @@ else
   start_client
 fi
 
-node_modules/.bin/darq-truffle test --network "$NETWORK"
+node_modules/.bin/truffle test --network "$NETWORK"

--- a/test/releaseDB.js
+++ b/test/releaseDB.js
@@ -530,6 +530,4 @@ contract('ReleaseDB', function(accounts){
       );
     })
   });
-
-
 });


### PR DESCRIPTION
+ Runs latest stable pragma. I think this could just be a brief intermediate step while we resolve warnings, before jumping up to `experimental v0.5.0` where they'll be enforced. 

+ Also upgrades truffle and fixes an incoherent test that (luckily) started failing with this change. 

NB: this solidity update introduces a number of new warnings. See [travis](https://travis-ci.org/ethpm/escape-truffle/jobs/402427284#L504)