### PR TITLE
Fix new warnings from upgrade to 0.4.24

### DIFF
--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -180,6 +180,7 @@ contract PackageDB is Authorized {
     pure
     returns (bytes32)
   {
-    return keccak256(name);
+    bytes memory hashArg = abi.encodePacked(name);
+    return keccak256(hashArg);
   }
 }

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -180,7 +180,6 @@ contract PackageDB is Authorized {
     pure
     returns (bytes32)
   {
-    bytes memory hashArg = abi.encodePacked(name);
-    return keccak256(hashArg);
+    return keccak256(abi.encodePacked(name));
   }
 }

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -176,7 +176,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
 
     // Lookup the current owner
     address packageOwner;
-    (packageOwner,) = getPackageData(name);
+    (packageOwner,,,) = getPackageData(name);
 
     // Log the transfer
     emit PackageTransfer(packageOwner, newPackageOwner);
@@ -446,7 +446,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     returns (bool)
   {
     address packageOwner;
-    (packageOwner,) = getPackageData(name);
+    (packageOwner,,,) = getPackageData(name);
     return (packageOwner != _address);
   }
 

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -353,7 +353,8 @@ contract ReleaseDB is Authorized {
     pure
     returns (bytes32)
   {
-    return keccak256(major, minor, patch, preRelease, build);
+    bytes memory hashArgs = abi.encodePacked(major, minor, patch, preRelease, build);
+    return keccak256(hashArgs);
   }
 
   /// @dev Returns release hash for the given release
@@ -364,7 +365,8 @@ contract ReleaseDB is Authorized {
     pure
     returns (bytes32)
   {
-    return keccak256(nameHash, versionHash);
+    bytes memory hashArgs = abi.encodePacked(nameHash, versionHash);
+    return keccak256(hashArgs);
   }
 
   /*

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -130,7 +130,7 @@ contract ReleaseDB is Authorized {
     uint32 minor;
     uint32 patch;
 
-    (nameHash, versionHash,) = getReleaseData(releaseHash);
+    (nameHash, versionHash,,) = getReleaseData(releaseHash);
     (major, minor, patch) = getMajorMinorPatch(versionHash);
 
     // In any branch of the release tree in which this version is the latest we
@@ -541,7 +541,7 @@ contract ReleaseDB is Authorized {
     bytes32 nameHash;
     bytes32 versionHash;
 
-    (nameHash, versionHash,) = getReleaseData(releaseHash);
+    (nameHash, versionHash,,) = getReleaseData(releaseHash);
 
     if (isLatestMajorTree(nameHash, versionHash)) {
       _latestMajor[nameHash] = releaseHash;
@@ -557,11 +557,11 @@ contract ReleaseDB is Authorized {
     bytes32 nameHash;
     bytes32 versionHash;
 
-    (nameHash, versionHash,) = getReleaseData(releaseHash);
+    (nameHash, versionHash,,) = getReleaseData(releaseHash);
 
     if (isLatestMinorTree(nameHash, versionHash)) {
       uint32 major;
-      (major,) = getMajorMinorPatch(versionHash);
+      (major,,) = getMajorMinorPatch(versionHash);
       _latestMinor[nameHash][major] = releaseHash;
       return true;
     } else {
@@ -575,7 +575,7 @@ contract ReleaseDB is Authorized {
     bytes32 nameHash;
     bytes32 versionHash;
 
-    (nameHash, versionHash,) = getReleaseData(releaseHash);
+    (nameHash, versionHash,,) = getReleaseData(releaseHash);
 
     if (isLatestPatchTree(nameHash, versionHash)) {
       uint32 major;
@@ -594,7 +594,7 @@ contract ReleaseDB is Authorized {
     bytes32 nameHash;
     bytes32 versionHash;
 
-    (nameHash, versionHash,) = getReleaseData(releaseHash);
+    (nameHash, versionHash,,) = getReleaseData(releaseHash);
 
     if (isLatestPreReleaseTree(nameHash, versionHash)) {
       uint32 major;

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -353,8 +353,7 @@ contract ReleaseDB is Authorized {
     pure
     returns (bytes32)
   {
-    bytes memory hashArgs = abi.encodePacked(major, minor, patch, preRelease, build);
-    return keccak256(hashArgs);
+    return keccak256(abi.encodePacked(major, minor, patch, preRelease, build));
   }
 
   /// @dev Returns release hash for the given release
@@ -365,8 +364,7 @@ contract ReleaseDB is Authorized {
     pure
     returns (bytes32)
   {
-    bytes memory hashArgs = abi.encodePacked(nameHash, versionHash);
-    return keccak256(hashArgs);
+    return keccak256(abi.encodePacked(nameHash, versionHash));
   }
 
   /*

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -74,7 +74,7 @@ contract ReleaseValidator {
     }
     address packageOwner;
 
-    (packageOwner,) = packageDb.getPackageData(nameHash);
+    (packageOwner,,) = packageDb.getPackageData(nameHash);
 
     if (packageOwner == callerAddress) {
       return true;
@@ -224,7 +224,7 @@ contract ReleaseValidator {
     returns (bool)
   {
     uint32 major;
-    (major,) = releaseDb.getMajorMinorPatch(versionHash);
+    (major,,) = releaseDb.getMajorMinorPatch(versionHash);
     return releaseDb.getLatestMinorTree(nameHash, major) != 0x0;
   }
 

--- a/contracts/SemVersionLib.sol
+++ b/contracts/SemVersionLib.sol
@@ -41,8 +41,7 @@ library SemVersionLib {
     self.preReleaseIdentifiers = splitIdentifiers(preRelease);
     self.build = build;
 
-    bytes memory hashArgs = abi.encodePacked(major, minor, patch, preRelease);
-    self.hash = keccak256(hashArgs);
+    self.hash = keccak256(abi.encodePacked(major, minor, patch, preRelease));
     return true;
   }
 

--- a/contracts/SemVersionLib.sol
+++ b/contracts/SemVersionLib.sol
@@ -40,7 +40,9 @@ library SemVersionLib {
     self.preRelease = preRelease;
     self.preReleaseIdentifiers = splitIdentifiers(preRelease);
     self.build = build;
-    self.hash = keccak256(major, minor, patch, preRelease);
+
+    bytes memory hashArgs = abi.encodePacked(major, minor, patch, preRelease);
+    self.hash = keccak256(hashArgs);
     return true;
   }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docs:gas": "NETWORK=ganache GAS_DOCS=true ./scripts/test.sh",
     "coverage": "./node_modules/.bin/solidity-coverage",
     "lint": "./node_modules/.bin/solium -d contracts/",
-    "compile": "./node_modules/.bin/darq-truffle compile",
+    "compile": "./node_modules/.bin/truffle compile",
     "ganache": "./node_modules/.bin/ganache-cli --noVMErrorsOnRPCResponse --port 8547",
     "ci": "./scripts/ci.sh"
   },


### PR DESCRIPTION
Two classes of new warnings addressed here:

+ `keccak256` now expects a single bytes param. Multiple string params are to be packed using [abi.encodePacked](https://solidity.readthedocs.io/en/v0.4.24/units-and-global-variables.html#abi-encoding-functions). Have implemented this as an intermediate call at the keccak invocation per form suggested by the solidity docs.
+ tuple assignments are now symmetry checked against the right hand side return args. 