### PR TITLE
Remove SemVersionLib concat methods

### DIFF
--- a/contracts/SemVersionLib.sol
+++ b/contracts/SemVersionLib.sol
@@ -320,28 +320,4 @@ library SemVersionLib {
 
     return value;
   }
-
-  /// @dev Concatenates the two strings together.
-  /// @param _head The first string
-  /// @param tail The second string
-  function concat(string storage _head, string tail) public returns (bool) {
-    bytes storage head = bytes(_head);
-
-    for (uint i = 0; i < bytes(tail).length; i++) {
-      head.push(bytes(tail)[i]);
-    }
-
-    _head = string(head);
-
-    return true;
-  }
-
-  /// @dev Concatenates the provided byte to the end of the provided string.
-  /// @param value The string to append the byte to.
-  /// @param b The byte.
-  function concatByte(string storage value, bytes1 b) public returns (bool) {
-    bytes memory _b = new bytes(1);
-    _b[0] = b;
-    return concat(value, string(_b));
-  }
 }


### PR DESCRIPTION
#14 

(Also resolves a linter warning in #3).

These public methods aren't consumed by any of the other contracts. 