### PR TITLE
Add pragma experimental v0.5.0

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 
 contract Authority {

--- a/contracts/IndexedOrderedSetLib.sol
+++ b/contracts/IndexedOrderedSetLib.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 /// @title Library implementing an array type which allows O(1) lookups on values.
 /// @author Piper Merriam <pipermerriam@gmail.com>

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 contract Migrations {
   address public owner;

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 import {SemVersionLib} from "./SemVersionLib.sol";
 import {IndexedOrderedSetLib} from "./IndexedOrderedSetLib.sol";

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 
 import {PackageDB} from "./PackageDB.sol";

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 
 import {AuthorizedInterface} from "./Authority.sol";

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 import {SemVersionLib} from "./SemVersionLib.sol";
 import {IndexedOrderedSetLib} from "./IndexedOrderedSetLib.sol";

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 import {PackageDB} from "./PackageDB.sol";
 import {ReleaseDB} from "./ReleaseDB.sol";

--- a/contracts/SemVersionLib.sol
+++ b/contracts/SemVersionLib.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
 
 /// @title Library which implements a semver datatype and comparisons.
 /// @author Piper Merriam <pipermerriam@gmail.com>


### PR DESCRIPTION
This is possible with #25 which removes the last of `0.4.x` compiler warnings. Recommended in the soldity docs [here](https://solidity.readthedocs.io/en/v0.4.24/security-considerations.html#take-warnings-seriously). 

NB: This PR targets the branch #25 is on for CI / could be redirected to `master` if that's approved.