### PR TITLE
Fix linter warnings / run linter in CI

### DIFF
--- a/contracts/IndexedOrderedSetLib.sol
+++ b/contracts/IndexedOrderedSetLib.sol
@@ -40,9 +40,9 @@ library IndexedOrderedSetLib {
   /// @param self The set
   /// @param value The value to look up the index for.
   function indexOf(IndexedOrderedSet storage self, bytes32 value)
-    requireValue(self, value)
     public
     view
+    requireValue(self, value)
     returns (uint)
   {
     return self._valueIndices[value];
@@ -71,8 +71,8 @@ library IndexedOrderedSetLib {
   /// @param self The set
   /// @param value The value to remove from the set.
   function remove(IndexedOrderedSet storage self, bytes32 value)
-    requireValue(self, value)
     public
+    requireValue(self, value)
     returns (bool)
   {
     uint idx = indexOf(self, value);

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -62,7 +62,7 @@ contract PackageDB is Authorized {
 
       // Set package data
       package.exists = true;
-      package.createdAt = block.timestamp;
+      package.createdAt = block.timestamp; // solium-disable-line security/no-block-members
       package.name = name;
 
       // Add the nameHash to the list of all package nameHashes.
@@ -71,7 +71,7 @@ contract PackageDB is Authorized {
       emit PackageCreate(nameHash);
     }
 
-    package.updatedAt = block.timestamp;
+    package.updatedAt = block.timestamp; // solium-disable-line security/no-block-members
 
     return true;
   }
@@ -104,7 +104,7 @@ contract PackageDB is Authorized {
     emit PackageOwnerUpdate(nameHash, _recordedPackages[nameHash].owner, newPackageOwner);
 
     _recordedPackages[nameHash].owner = newPackageOwner;
-    _recordedPackages[nameHash].updatedAt = block.timestamp;
+    _recordedPackages[nameHash].updatedAt = block.timestamp; // solium-disable-line security/no-block-members
 
     return true;
   }

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -93,7 +93,7 @@ contract ReleaseDB is Authorized {
     } else {
       // Populate the basic rlease data.
       release.exists = true;
-      release.createdAt = block.timestamp;
+      release.createdAt = block.timestamp; // solium-disable-line security/no-block-members
       release.nameHash = nameHash;
       release.versionHash = versionHash;
 
@@ -105,7 +105,7 @@ contract ReleaseDB is Authorized {
     }
 
     // Record the last time the release was updated.
-    release.updatedAt = block.timestamp;
+    release.updatedAt = block.timestamp; // solium-disable-line security/no-block-members
 
     // Save the release lockfile URI
     release.releaseLockfileURI = releaseLockfileURI;

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -275,9 +275,9 @@ contract ReleaseDB is Authorized {
   /// @dev Returns the releaseHash at the given index for a package.
   /// @param releaseHash The release hash.
   function getReleaseData(bytes32 releaseHash)
-    onlyIfReleaseExists(releaseHash)
     public
     view
+    onlyIfReleaseExists(releaseHash)
     returns (
       bytes32 nameHash,
       bytes32 versionHash,
@@ -292,9 +292,9 @@ contract ReleaseDB is Authorized {
   /// @dev Returns a 3-tuple of the major, minor, and patch components from the version of the given release hash.
   /// @param versionHash the version hash
   function getMajorMinorPatch(bytes32 versionHash)
-    onlyIfVersionExists(versionHash)
     public
     view
+    onlyIfVersionExists(versionHash)
     returns (uint32, uint32, uint32)
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
@@ -304,9 +304,9 @@ contract ReleaseDB is Authorized {
   /// @dev Returns the pre-release string from the version of the given release hash.
   /// @param releaseHash Release hash
   function getPreRelease(bytes32 releaseHash)
-    onlyIfReleaseExists(releaseHash)
     public
     view
+    onlyIfReleaseExists(releaseHash)
     returns (string)
   {
     return _recordedVersions[_recordedReleases[releaseHash].versionHash].preRelease;
@@ -315,9 +315,9 @@ contract ReleaseDB is Authorized {
   /// @dev Returns the build string from the version of the given release hash.
   /// @param releaseHash Release hash
   function getBuild(bytes32 releaseHash)
-    onlyIfReleaseExists(releaseHash)
     public
     view
+    onlyIfReleaseExists(releaseHash)
     returns (string)
   {
     return _recordedVersions[_recordedReleases[releaseHash].versionHash].build;
@@ -326,9 +326,9 @@ contract ReleaseDB is Authorized {
   /// @dev Returns the URI of the release lockfile for the given release hash.
   /// @param releaseHash Release hash
   function getReleaseLockfileURI(bytes32 releaseHash)
-    onlyIfReleaseExists(releaseHash)
     public
     view
+    onlyIfReleaseExists(releaseHash)
     returns (string)
   {
     return _recordedReleases[releaseHash].releaseLockfileURI;
@@ -431,9 +431,9 @@ contract ReleaseDB is Authorized {
   /// @param nameHash The nameHash of the package to check against.
   /// @param versionHash The versionHash of the version to check.
   function isLatestMajorTree(bytes32 nameHash, bytes32 versionHash)
-    onlyIfVersionExists(versionHash)
     public
     view
+    onlyIfVersionExists(versionHash)
     returns (bool)
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
@@ -452,9 +452,9 @@ contract ReleaseDB is Authorized {
   /// @param nameHash The nameHash of the package to check against.
   /// @param versionHash The versionHash of the version to check.
   function isLatestMinorTree(bytes32 nameHash, bytes32 versionHash)
-    onlyIfVersionExists(versionHash)
     public
     view
+    onlyIfVersionExists(versionHash)
     returns (bool)
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
@@ -473,9 +473,9 @@ contract ReleaseDB is Authorized {
   /// @param nameHash The nameHash of the package to check against.
   /// @param versionHash The versionHash of the version to check.
   function isLatestPatchTree(bytes32 nameHash, bytes32 versionHash)
-    onlyIfVersionExists(versionHash)
     public
     view
+    onlyIfVersionExists(versionHash)
     returns (bool)
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
@@ -498,9 +498,9 @@ contract ReleaseDB is Authorized {
   /// @param nameHash The nameHash of the package to check against.
   /// @param versionHash The versionHash of the version to check.
   function isLatestPreReleaseTree(bytes32 nameHash, bytes32 versionHash)
-    onlyIfVersionExists(versionHash)
     public
     view
+    onlyIfVersionExists(versionHash)
     returns (bool)
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
@@ -533,8 +533,8 @@ contract ReleaseDB is Authorized {
   /// @dev Sets the given release as the new leaf of the major branch of the release tree if it is greater or equal to the current leaf.
   /// @param releaseHash The release hash of the release to check.
   function updateMajorTree(bytes32 releaseHash)
-    onlyIfReleaseExists(releaseHash)
     internal
+    onlyIfReleaseExists(releaseHash)
     returns (bool)
   {
     bytes32 nameHash;

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -438,7 +438,7 @@ contract ReleaseDB is Authorized {
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
 
-    SemVersionLib.SemVersion storage latestMajor =
+    SemVersionLib.SemVersion storage latestMajor = // solium-disable-line operator-whitespace
       _recordedVersions[
         _recordedReleases[
           getLatestMajorTree(nameHash)
@@ -459,7 +459,7 @@ contract ReleaseDB is Authorized {
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
 
-    SemVersionLib.SemVersion storage latestMinor =
+    SemVersionLib.SemVersion storage latestMinor = // solium-disable-line operator-whitespace
       _recordedVersions[
         _recordedReleases[
           getLatestMinorTree(nameHash, version.major)
@@ -480,7 +480,7 @@ contract ReleaseDB is Authorized {
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
 
-    SemVersionLib.SemVersion storage latestPatch =
+    SemVersionLib.SemVersion storage latestPatch = // solium-disable-line operator-whitespace
       _recordedVersions[
         _recordedReleases[
           getLatestPatchTree(
@@ -505,7 +505,7 @@ contract ReleaseDB is Authorized {
   {
     SemVersionLib.SemVersion storage version = _recordedVersions[versionHash];
 
-    SemVersionLib.SemVersion storage latestPreRelease =
+    SemVersionLib.SemVersion storage latestPreRelease = // solium-disable-line operator-whitespace
       _recordedVersions[
         _recordedReleases[
           getLatestPreReleaseTree(

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://github.com/ethpm/escape-truffle#readme",
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "darq-truffle": "4.1.4-next.7",
     "eth-gas-reporter": "^0.1.7",
     "ganache-cli": "6.1.0",
     "shelljs": "^0.8.1",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -69,4 +69,5 @@ else
   start_client
 fi
 
+npm run lint
 node_modules/.bin/truffle test --network "$NETWORK"


### PR DESCRIPTION
#3 

Following guidance of some new warnings in the latest Solium that recommend `public` modifiers be sequenced first in the modifier lists. 

Have disabled warnings about:
+ `block.timestamp`: these values just stamp package creation / update dates . No consequential logic (within the contracts themselves) is tied to them. 
+ some `operator-whitespace` warnings about lack of symmetry in a few locations where the right hand side of an assignment expression extends beyond GitHub's view window. Stepping those down onto subsequent lines for accessibility. 

Also starting to run linter in CI and on `npm test` - we should start getting failures if style & security rules are violated. 

Currently only have warnings about the absence of reason strings in our revert statements.