### PR TITLE
Add reason strings

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -19,7 +19,7 @@ contract AuthorizedInterface {
   Authority public authority;
 
   modifier auth {
-    require(isAuthorized(),"ethpm@authority:caller-not-authorized");
+    require(isAuthorized(),"escape:Authority:caller-not-authorized");
     _;
   }
 

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -19,7 +19,7 @@ contract AuthorizedInterface {
   Authority public authority;
 
   modifier auth {
-    require(isAuthorized());
+    require(isAuthorized(),"ethpm@authority:caller-not-authorized");
     _;
   }
 

--- a/contracts/IndexedOrderedSetLib.sol
+++ b/contracts/IndexedOrderedSetLib.sol
@@ -11,7 +11,7 @@ library IndexedOrderedSetLib {
   }
 
   modifier requireValue(IndexedOrderedSet storage self, bytes32 value) {
-    require(contains(self, value));
+    require(contains(self, value), "ethpm@setLib:set-does-not-contain-val");
     _;
   }
 

--- a/contracts/IndexedOrderedSetLib.sol
+++ b/contracts/IndexedOrderedSetLib.sol
@@ -11,7 +11,7 @@ library IndexedOrderedSetLib {
   }
 
   modifier requireValue(IndexedOrderedSet storage self, bytes32 value) {
-    require(contains(self, value), "ethpm@setLib:set-does-not-contain-val");
+    require(contains(self, value), "escape:IndexedOrderedSetLib:value-not-found");
     _;
   }
 

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -35,7 +35,7 @@ contract PackageDB is Authorized {
    *  Modifiers
    */
   modifier onlyIfPackageExists(bytes32 nameHash) {
-    require(packageExists(nameHash), "ethpm@packageDB:package-does-not-exist");
+    require(packageExists(nameHash), "escape:PackageDB:package-not-found");
     _;
   }
 

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -35,7 +35,7 @@ contract PackageDB is Authorized {
    *  Modifiers
    */
   modifier onlyIfPackageExists(bytes32 nameHash) {
-    require(packageExists(nameHash));
+    require(packageExists(nameHash), "ethpm@packageDB:package-does-not-exist");
     _;
   }
 

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -79,9 +79,9 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     auth
     returns (bool)
   {
-    require(address(packageDb) != 0x0,        "ethpm@index:no-packageDB-address");
-    require(address(releaseDb) != 0x0,        "ethpm@index:no-releaseDB-address");
-    require(address(releaseValidator) != 0x0, "ethpm@index:no-validator-address");
+    require(address(packageDb) != 0x0,        "escape:PackageIndex:package-db-not-set");
+    require(address(releaseDb) != 0x0,        "escape:PackageIndex:release-db-not-set");
+    require(address(releaseValidator) != 0x0, "escape:PackageIndex:release-validator-not-set");
 
     return release(name, [major, minor, patch], preRelease, build, releaseLockfileURI);
   }

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -79,9 +79,10 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     auth
     returns (bool)
   {
-    require(address(packageDb) != 0x0);
-    require(address(releaseDb) != 0x0);
-    require(address(releaseValidator) != 0x0);
+    require(address(packageDb) != 0x0,        "ethpm@index:no-packageDB-address");
+    require(address(releaseDb) != 0x0,        "ethpm@index:no-releaseDB-address");
+    require(address(releaseValidator) != 0x0, "ethpm@index:no-validator-address");
+
     return release(name, [major, minor, patch], preRelease, build, releaseLockfileURI);
   }
 

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -54,12 +54,12 @@ contract ReleaseDB is Authorized {
    *  Modifiers
    */
   modifier onlyIfVersionExists(bytes32 versionHash) {
-    require(versionExists(versionHash));
+    require(versionExists(versionHash), "ethpm@releaseDB:version-does-not-exist");
     _;
   }
 
   modifier onlyIfReleaseExists(bytes32 releaseHash) {
-    require(releaseExists(releaseHash));
+    require(releaseExists(releaseHash), "ethpm@releaseDB:release-does-not-exist");
     _;
   }
 

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -54,12 +54,12 @@ contract ReleaseDB is Authorized {
    *  Modifiers
    */
   modifier onlyIfVersionExists(bytes32 versionHash) {
-    require(versionExists(versionHash), "ethpm@releaseDB:version-does-not-exist");
+    require(versionExists(versionHash), "escape:ReleaseDB:version-not-found");
     _;
   }
 
   modifier onlyIfReleaseExists(bytes32 releaseHash) {
-    require(releaseExists(releaseHash), "ethpm@releaseDB:release-does-not-exist");
+    require(releaseExists(releaseHash), "escape:ReleaseDB:release-not-found");
     _;
   }
 

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -30,8 +30,8 @@ contract ReleaseValidator {
     view
     returns (bool)
   {
-    require(address(packageDb) != 0x0, "ethpm@validator:no-packageDB-address");
-    require(address(releaseDb) != 0x0, "ethpm@validator:no-releaseDB-address");
+    require(address(packageDb) != 0x0, "escape:ReleaseValidator:package-db-not-set");
+    require(address(releaseDb) != 0x0, "escape:ReleaseValidator:release-db-not-set");
 
     if (!validateAuthorization(packageDb, callerAddress, name)) {
       // package exists and msg.sender is not the owner not the package owner.

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -30,8 +30,8 @@ contract ReleaseValidator {
     view
     returns (bool)
   {
-    require(address(packageDb) != 0x0);
-    require(address(releaseDb) != 0x0);
+    require(address(packageDb) != 0x0, "ethpm@validator:no-packageDB-address");
+    require(address(releaseDb) != 0x0, "ethpm@validator:no-releaseDB-address");
 
     if (!validateAuthorization(packageDb, callerAddress, name)) {
       // package exists and msg.sender is not the owner not the package owner.

--- a/test/whitelistAuthority.js
+++ b/test/whitelistAuthority.js
@@ -31,7 +31,7 @@ contract('WhitelistAuthority', function(accounts){
 
       it('should set a new Owner', async function(){
         assert(await authorized.owner() === accounts[0]);
-        authorized.setOwner(accounts[1]);
+        await authorized.setOwner(accounts[1]);
         assert(await authorized.owner() === accounts[1]);
       });
 


### PR DESCRIPTION
#3 #17

Adds error reason strings to require statements using the pattern: 
```
"<project>@<contract>:<human-readable-reason>"
```

Believe whatever additional costs are incurred by having a more intelligible string are borne by the deployment. Cost appears to be +/- 200,000 gas per contract. There is no charge for the method call return data and it's not clear that there will be any size limits. 

All of this is also in the shadow [EIP 838](https://github.com/ethereum/EIPs/issues/838) which looks like a cheaper and clearer solution to this question.

-------------
**Survey** of existing styles for comparison:

+ [colony](https://github.com/JoinColony/colonyNetwork/blob/develop/contracts/Colony.sol#L59)
```javascript
require(colonyNetworkAddress == 0x0, "colony-initialise-bad-address");
```
+ [zos-libs](https://github.com/zeppelinos/zos-lib/blob/master/contracts/application/BaseApp.sol#L22)
```javascript
require(address(_factory) != address(0), "Cannot set the proxy factory of an app to the zero address");
```
+ [OxProject](https://github.com/0xProject/0x-monorepo/blob/v2-prototype/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol#L88-L91)
```javascript
require(
  assetData.length > 3,
  "LENGTH_GREATER_THAN_3_REQUIRED"
);
```

**Bonus**
Thoughtful [discussion](https://github.com/OpenZeppelin/openzeppelin-solidity/issues/888) of this topic by the principals at Zeppelin. 

