### PR TITLE
Fix geth in CI & upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - NETWORK=ganache GAS_REPORTER=true
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env: NETWORK=coverage
     - env: NETWORK=geth

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 before_install:
-  - docker pull ethereum/client-go:v1.8.6
+  - docker pull ethereum/client-go:latest
 
 env:
   - NETWORK=ganache

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eth-gas-reporter": "^0.1.7",
-    "ganache-cli": "6.1.0",
+    "ganache-cli": "6.1.6",
     "shelljs": "^0.8.1",
     "solidity-coverage": "^0.5.0",
     "solium": "^1.1.7",
-    "truffle": "^5.0.0-next.2"
+    "truffle": "5.0.0-next.3"
   }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,7 @@ cleanup() {
 
 # Set client port
 if [ "$NETWORK" = "geth" ]; then
-  PORT=8546 # websockets
+  PORT=8545
 fi
 
 if [ "$NETWORK" = "ganache" ]; then
@@ -36,24 +36,24 @@ client_running() {
 start_client() {
   if [ "$NETWORK" = "geth" ]; then
     docker run \
-      -v /"$PWD"/scripts:/scripts \
+      -v /$PWD/scripts:/scripts \
       -d \
-      -p 8546:8546 \
+      -p 8545:8545 \
       -p 30303:30303 \
-      ethereum/client-go:v1.8.6 \
-      --nodiscover \
+      ethereum/client-go:latest \
+      --rpc \
+      --rpcaddr '0.0.0.0' \
+      --rpcport 8545 \
       --rpccorsdomain '*' \
-      --ws \
-      --wsaddr '0.0.0.0' \
-      --wsorigins '*' \
+      --nodiscover \
       --dev \
       --dev.period 1 \
       --targetgaslimit '8000000' \
       js ./scripts/geth-accounts.js \
       > /dev/null &
 
-      echo "Pausing for 30s to complete client launch."
-      sleep 30
+      echo "Pausing for 2 minutes of auto-mining to approach target gaslimit."
+      sleep 120
 
   else
     node_modules/.bin/ganache-cli --noVMErrorsOnRPCResponse --port "$PORT"> /dev/null &

--- a/test/packageDB.js
+++ b/test/packageDB.js
@@ -17,7 +17,7 @@ contract('PackageDB', function(accounts){
     nameHash = await packageDB.hashName(packageName);
   });
 
-  describe('setPackage', function(){
+  describe('setPackage [ @geth ]', function(){
     it('should create a package record', async function(){
       const now = helpers.now();
       await packageDB.setPackage(packageName);
@@ -53,7 +53,7 @@ contract('PackageDB', function(accounts){
     });
   });
 
-  describe('setPackageOwner', function(){
+  describe('setPackageOwner [ @geth ]', function(){
     const owner = accounts[1];
 
     it('should set the package owner', async function(){
@@ -83,7 +83,7 @@ contract('PackageDB', function(accounts){
     });
   });
 
-  describe('removePackage', function(){
+  describe('removePackage [ @geth ]', function(){
     let reason = `
       In order to possess what you do not possess
         You must go by the way of dispossession.

--- a/test/packageDB.js
+++ b/test/packageDB.js
@@ -2,7 +2,7 @@ const helpers = require('./helpers');
 const PackageDB = artifacts.require('PackageDB');
 const constants = helpers.constants;
 const assertFailure = helpers.assertFailure;
-const assertRevert = helpers.assertRevert;
+const assertCallFailure = helpers.assertCallFailure;
 
 contract('PackageDB', function(accounts){
   let semVersionLib;
@@ -104,7 +104,7 @@ contract('PackageDB', function(accounts){
       assert(!exists);
       assert(num === (0).toString());
 
-      await assertRevert(
+      await assertCallFailure(
         packageDB.getPackageData(nameHash)
       );
     });
@@ -120,7 +120,7 @@ contract('PackageDB', function(accounts){
       let exists = await packageDB.packageExists(nameHash);
       assert(!exists);
 
-      await assertRevert(
+      await assertFailure(
         packageDB.removePackage(nameHash, reason)
       );
     });

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -76,7 +76,7 @@ contract('PackageIndex', function(accounts){
       authority = await WhitelistAuthority.new();
     })
 
-    it('should release when initialized correctly', async function(){
+    it('should release when initialized correctly [ @geth ]', async function(){
       packageDB = await PackageDB.new();
       releaseDB = await ReleaseDB.new();
       releaseValidator = await ReleaseValidator.new();
@@ -206,7 +206,7 @@ contract('PackageIndex', function(accounts){
     })
 
     describe('getters', function(){
-      it('packageDb', async function(){
+      it('packageDb [ @geth ]', async function(){
         assert(await packageIndex.getPackageDb() === packageDB.address);
       });
 
@@ -220,7 +220,7 @@ contract('PackageIndex', function(accounts){
     });
 
     describe('releases', function(){
-      it('should retrieve release by index', async function(){
+      it('should retrieve release by index [ @geth ]', async function(){
         const releaseInfoA = ['test', 1, 2, 3, 'a', 'b', 'ipfs://some-ipfs-uri']
         const releaseInfoB = ['test', 2, 3, 4, 'c', 'd', 'ipfs://some-other-ipfs-uri']
 
@@ -376,7 +376,7 @@ contract('PackageIndex', function(accounts){
       })
     });
 
-    describe('Ownership', function(){
+    describe('Ownership [ @geth ]', function(){
       const info = ['test-a', 1, 2, 3, '', '', 'ipfs://some-ipfs-uri'];
       const owner = accounts[0];
       const newOwner = accounts[1];

--- a/test/releaseDB.js
+++ b/test/releaseDB.js
@@ -109,7 +109,7 @@ contract('ReleaseDB', function(accounts){
   });
 
   describe('Releases: Version Tracking Cases', function(){
-    it('v100vh', async function(){
+    it('v100vh [ @geth ]', async function(){
       await releaseDB.setRelease(
         nameHash,
         v100vh,
@@ -491,7 +491,7 @@ contract('ReleaseDB', function(accounts){
 
   });
 
-  describe('Getters', function(){
+  describe('Getters [ @geth ]', function(){
     let nameHash;
     let versionHash;
     let releaseHash;

--- a/test/releaseDB.js
+++ b/test/releaseDB.js
@@ -6,7 +6,7 @@
 const helpers = require('./helpers');
 const constants = helpers.constants;
 const assertFailure = helpers.assertFailure;
-const assertRevert = helpers.assertRevert;
+const assertCallFailure = helpers.assertCallFailure;
 
 const PackageDB = artifacts.require('PackageDB');
 const ReleaseDB = artifacts.require('ReleaseDB');
@@ -537,14 +537,14 @@ contract('ReleaseDB', function(accounts){
       assert( majorMinorPatch['2'] === (3).toString());
     });
 
-    it('throws when querying a version that does not exist', async function(){
+    it('returns false (or errors) when querying a version that does not exist', async function(){
       const nameHash = await packageDB.hashName('test');
       const trueVersionHash = await releaseDB.hashVersion(2, 0, 0, '', '');
       const falseVersionHash = await releaseDB.hashVersion(0, 0, 0, '', '');
 
       assert( await releaseDB.isLatestMajorTree(nameHash, trueVersionHash) );
 
-      await assertRevert(
+      await assertCallFailure(
         releaseDB.isLatestMajorTree(nameHash, falseVersionHash)
       );
     })

--- a/test/releaseValidator.js
+++ b/test/releaseValidator.js
@@ -84,7 +84,7 @@ contract('ReleaseValidator', function(accounts){
       prerelease: ['test', 1, 1, 1, 'beta.1', '', uri ]
     };
 
-    it('should not release 0, 0, 0', async function(){
+    it('should not release 0, 0, 0 [ @geth ]', async function(){
       const info = releases.zero;
       assert( await packageIndex.packageExists(info[0]) === false );
 

--- a/test/whitelistAuthority.js
+++ b/test/whitelistAuthority.js
@@ -11,14 +11,13 @@ contract('WhitelistAuthority', function(accounts){
     describe('constructor', function(){
       before(async () => authorized = await WhitelistAuthority.new());
 
-      it('should set an owner on deployment', async function(){
+      it('should set an owner on deployment [ @geth ]', async function(){
         assert(await authorized.owner() === accounts[0]);
       });
 
       it('should emit `OwnerUpdate`', async function(){
         const events = await authorized.getPastEvents('OwnerUpdate');
         const event = events[0];
-
         assert(events.length === 1);
         assert(event.event === 'OwnerUpdate');
         assert(event.returnValues.oldOwner === constants.zeroAddress);
@@ -26,7 +25,7 @@ contract('WhitelistAuthority', function(accounts){
       })
     });
 
-    describe('setOwner', function(){
+    describe('setOwner [ @geth ]', function(){
       before(async () => authorized = await WhitelistAuthority.new());
 
       it('should set a new Owner', async function(){
@@ -55,7 +54,7 @@ contract('WhitelistAuthority', function(accounts){
         signature = WhitelistAuthority.abi.find(item => item.name === 'setAuthority').signature;
       })
 
-      it('should allow the owner to set the authority', async function(){
+      it('should allow the owner to set the authority [ @geth ]', async function(){
         const newAuthority = accounts[1];
         await whitelist.setAuthority(newAuthority);
         assert(await whitelist.authority() === newAuthority);
@@ -79,7 +78,7 @@ contract('WhitelistAuthority', function(accounts){
           });
       });
 
-      it('should not allow non-owner to set the authority', async function(){
+      it('should not allow non-owner to set the authority [ @geth ]', async function(){
         const nonOwner = accounts[8];
 
         const currentOwner = await whitelist.owner();

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,11 +18,17 @@ const mochaGasSettingsDocs = {
   }
 }
 
+const mochaGeth = {
+  grep: "geth",
+}
+
 let mocha = {};
 if (process.env.GAS_REPORTER){
   mocha = mochaGasSettingsShell
 } else if (process.env.GAS_DOCS){
   mocha = mochaGasSettingsDocs
+} else if (process.env.NETWORK === 'geth'){
+  mocha = mochaGeth
 }
 
 module.exports = {
@@ -35,9 +41,8 @@ module.exports = {
     },
     geth: {
       host: "127.0.0.1",
-      port: 8546,
+      port: 8545,
       network_id: "*",
-      websockets: true
     },
     coverage: {
       host: "127.0.0.1",


### PR DESCRIPTION
#10 

+ truffle@next.3 (reason string support)
+ ganache-cli 6.1.6 (reason string support)
+ start running just a subset of tests on Geth due to time constraints. Don't use websockets because contracts are too big to deploy over that channel due to unresolved geth [issue](https://github.com/ethereum/go-ethereum/issues/16846)
+ fix test assertion helper so that it processes variant responses to require gate failures by the three clients we run the suite against
