### PR TITLE
Allow package names to have 255 chars

### DIFF
--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -128,7 +128,7 @@ contract ReleaseValidator {
       return true;
     }
 
-    if (bytes(name).length < 2 || bytes(name).length > 214) {
+    if (bytes(name).length < 2 || bytes(name).length > 255) {
       return false;
     }
     for (uint i = 0; i < bytes(name).length; i++) {

--- a/test/releaseValidator.js
+++ b/test/releaseValidator.js
@@ -469,8 +469,8 @@ contract('ReleaseValidator', function(accounts){
 
       it('a * 256', async function(){
         info[0] = cases.a256;
-        await assertDoesNotRelease(packageIndex, info);
-\      })
+        await assertDoesNotRelease(packageIndex, info, 'invalid-package-name');
+      })
 
       it('-starts-with-dash', async function(){
         info[0] = cases.startsDash;

--- a/test/releaseValidator.js
+++ b/test/releaseValidator.js
@@ -396,13 +396,13 @@ contract('ReleaseValidator', function(accounts){
     const cases = {
       // Good
       aa: 'aa',
-      a214: 'a'.repeat(214),
+      a255: 'a'.repeat(255),
       dashes: 'contains-dashes',
       numbers: 'contains-1234567890-numbers',
       allAllowed: 'contains-abcdefghijklmnopqrstuvwxyz-1234567890-all-allowed-chars',
       // Bad
       a: 'a',
-      a215: 'a'.repeat(215),
+      a256: 'a'.repeat(256),
       startsDash: '-starts-with-dash',        // starts with a dash
       startsNumber: '9starts-with-number',    // starts with a number
       hasCaps: 'hasCapitals',                // capital letters.
@@ -440,8 +440,8 @@ contract('ReleaseValidator', function(accounts){
         await assertReleases(packageIndex, info);
       })
 
-      it('a * 214', async function(){
-        info[0] = cases.a214;
+      it('a * 255', async function(){
+        info[0] = cases.a255;
         await assertReleases(packageIndex, info);
       })
 
@@ -467,10 +467,10 @@ contract('ReleaseValidator', function(accounts){
         await assertDoesNotRelease(packageIndex, info, 'invalid-package-name');
       });
 
-      it('a * 215', async function(){
-        info[0] = cases.a215;
-        await assertDoesNotRelease(packageIndex, info, 'invalid-package-name');
-      })
+      it('a * 256', async function(){
+        info[0] = cases.a256;
+        await assertDoesNotRelease(packageIndex, info);
+\      })
 
       it('-starts-with-dash', async function(){
         info[0] = cases.startsDash;


### PR DESCRIPTION
+ Updates `ReleaseValidator` contract to reflect V2 spec [package name length requirements](http://ethpm.github.io/ethpm-spec/package-spec.html#package-name-package-name) 
+ Updates unit tests