### PR TITLE
Rename lockfile to manifest

### DIFF
--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -65,7 +65,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseLockfileURI The URI for the release lockfile for this release.
+  /// @param releaseManifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32 major,
@@ -73,7 +73,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     uint32 patch,
     string preRelease,
     string build,
-    string releaseLockfileURI
+    string releaseManifestURI
   )
     public
     auth
@@ -83,7 +83,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     require(address(releaseDb) != 0x0,        "escape:PackageIndex:release-db-not-set");
     require(address(releaseValidator) != 0x0, "escape:PackageIndex:release-validator-not-set");
 
-    return release(name, [major, minor, patch], preRelease, build, releaseLockfileURI);
+    return release(name, [major, minor, patch], preRelease, build, releaseManifestURI);
   }
 
   /// @dev Creates a a new release for the named package.  If this is the first release for the given package then this will also assign msg.sender as the owner of the package.  Returns success.
@@ -92,13 +92,13 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param majorMinorPatch The major/minor/patch portion of the version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseLockfileURI The URI for the release lockfile for this release.
+  /// @param releaseManifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32[3] majorMinorPatch,
     string preRelease,
     string build,
-    string releaseLockfileURI
+    string releaseManifestURI
   )
     internal
     returns (bool)
@@ -134,7 +134,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
       majorMinorPatch,
       preRelease,
       build,
-      releaseLockfileURI
+      releaseManifestURI
     );
 
     // Compute hashes
@@ -152,7 +152,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     }
 
     // Create the release and add it to the list of package release hashes.
-    releaseDb.setRelease(nameHash, versionHash, releaseLockfileURI);
+    releaseDb.setRelease(nameHash, versionHash, releaseManifestURI);
 
     // Log the release.
     emit PackageRelease(nameHash, releaseDb.hashRelease(nameHash, versionHash));
@@ -302,7 +302,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
       uint32 patch,
       string preRelease,
       string build,
-      string releaseLockfileURI,
+      string releaseManifestURI,
       uint createdAt,
       uint updatedAt
     )
@@ -312,8 +312,8 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     (major, minor, patch) = releaseDb.getMajorMinorPatch(versionHash);
     preRelease = getPreRelease(releaseHash);
     build = getBuild(releaseHash);
-    releaseLockfileURI = getReleaseLockfileURI(releaseHash);
-    return (major, minor, patch, preRelease, build, releaseLockfileURI, createdAt, updatedAt);
+    releaseManifestURI = getReleaseManifestURI(releaseHash);
+    return (major, minor, patch, preRelease, build, releaseManifestURI, createdAt, updatedAt);
   }
 
   /// @dev Returns the release hash at the provide index in the array of all release hashes.
@@ -407,14 +407,14 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     return releaseHashes;
   }
 
-  /// @dev Returns the release lockfile for the given release data
+  /// @dev Returns the release manifest for the given release data
   /// @param name Package name
   /// @param major The major portion of the semver version string.
   /// @param minor The minor portion of the semver version string.
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getReleaseLockfileURI(
+  function getReleaseManifestURI(
     string name,
     uint32 major,
     uint32 minor,
@@ -428,7 +428,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   {
     bytes32 versionHash = releaseDb.hashVersion(major, minor, patch, preRelease, build);
     bytes32 releaseHash = releaseDb.hashRelease(packageDb.hashName(name), versionHash);
-    return getReleaseLockfileURI(releaseHash);
+    return getReleaseManifestURI(releaseHash);
   }
 
 
@@ -460,14 +460,14 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     return PackageDB(packageDb).getPackageName(nameHash);
   }
 
-  /// @dev Retrieves the release lockfile URI from the package db.
+  /// @dev Retrieves the release manifest URI from the package db.
   /// @param releaseHash The release hash to retrieve the URI from.
-  function getReleaseLockfileURI(bytes32 releaseHash)
+  function getReleaseManifestURI(bytes32 releaseHash)
     internal
     view
     returns (string)
   {
-    return ReleaseDB(releaseDb).getReleaseLockfileURI(releaseHash);
+    return ReleaseDB(releaseDb).getReleaseManifestURI(releaseHash);
   }
 
   /// @dev Retrieves the pre-release string from the package db.

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -65,7 +65,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseManifestURI The URI for the release manifest for this release.
+  /// @param manifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32 major,
@@ -73,7 +73,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     uint32 patch,
     string preRelease,
     string build,
-    string releaseManifestURI
+    string manifestURI
   )
     public
     auth
@@ -83,7 +83,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     require(address(releaseDb) != 0x0,        "escape:PackageIndex:release-db-not-set");
     require(address(releaseValidator) != 0x0, "escape:PackageIndex:release-validator-not-set");
 
-    return release(name, [major, minor, patch], preRelease, build, releaseManifestURI);
+    return release(name, [major, minor, patch], preRelease, build, manifestURI);
   }
 
   /// @dev Creates a a new release for the named package.  If this is the first release for the given package then this will also assign msg.sender as the owner of the package.  Returns success.
@@ -92,13 +92,13 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param majorMinorPatch The major/minor/patch portion of the version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseManifestURI The URI for the release manifest for this release.
+  /// @param manifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32[3] majorMinorPatch,
     string preRelease,
     string build,
-    string releaseManifestURI
+    string manifestURI
   )
     internal
     returns (bool)
@@ -134,7 +134,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
       majorMinorPatch,
       preRelease,
       build,
-      releaseManifestURI
+      manifestURI
     );
 
     // Compute hashes
@@ -152,7 +152,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     }
 
     // Create the release and add it to the list of package release hashes.
-    releaseDb.setRelease(nameHash, versionHash, releaseManifestURI);
+    releaseDb.setRelease(nameHash, versionHash, manifestURI);
 
     // Log the release.
     emit PackageRelease(nameHash, releaseDb.hashRelease(nameHash, versionHash));
@@ -302,7 +302,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
       uint32 patch,
       string preRelease,
       string build,
-      string releaseManifestURI,
+      string manifestURI,
       uint createdAt,
       uint updatedAt
     )
@@ -312,8 +312,8 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     (major, minor, patch) = releaseDb.getMajorMinorPatch(versionHash);
     preRelease = getPreRelease(releaseHash);
     build = getBuild(releaseHash);
-    releaseManifestURI = getReleaseManifestURI(releaseHash);
-    return (major, minor, patch, preRelease, build, releaseManifestURI, createdAt, updatedAt);
+    manifestURI = getManifestURI(releaseHash);
+    return (major, minor, patch, preRelease, build, manifestURI, createdAt, updatedAt);
   }
 
   /// @dev Returns the release hash at the provide index in the array of all release hashes.
@@ -414,7 +414,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getReleaseManifestURI(
+  function getManifestURI(
     string name,
     uint32 major,
     uint32 minor,
@@ -428,7 +428,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   {
     bytes32 versionHash = releaseDb.hashVersion(major, minor, patch, preRelease, build);
     bytes32 releaseHash = releaseDb.hashRelease(packageDb.hashName(name), versionHash);
-    return getReleaseManifestURI(releaseHash);
+    return getManifestURI(releaseHash);
   }
 
 
@@ -462,12 +462,12 @@ contract PackageIndex is Authorized, PackageIndexInterface {
 
   /// @dev Retrieves the release manifest URI from the package db.
   /// @param releaseHash The release hash to retrieve the URI from.
-  function getReleaseManifestURI(bytes32 releaseHash)
+  function getManifestURI(bytes32 releaseHash)
     internal
     view
     returns (string)
   {
-    return ReleaseDB(releaseDb).getReleaseManifestURI(releaseHash);
+    return ReleaseDB(releaseDb).getManifestURI(releaseHash);
   }
 
   /// @dev Retrieves the pre-release string from the package db.

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -312,7 +312,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     (major, minor, patch) = releaseDb.getMajorMinorPatch(versionHash);
     preRelease = getPreRelease(releaseHash);
     build = getBuild(releaseHash);
-    manifestURI = getManifestURI(releaseHash);
+    manifestURI = getReleaseManifestURI(releaseHash);
     return (major, minor, patch, preRelease, build, manifestURI, createdAt, updatedAt);
   }
 
@@ -414,7 +414,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getManifestURI(
+  function getReleaseManifestURI(
     string name,
     uint32 major,
     uint32 minor,
@@ -428,7 +428,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   {
     bytes32 versionHash = releaseDb.hashVersion(major, minor, patch, preRelease, build);
     bytes32 releaseHash = releaseDb.hashRelease(packageDb.hashName(name), versionHash);
-    return getManifestURI(releaseHash);
+    return getReleaseManifestURI(releaseHash);
   }
 
 
@@ -462,7 +462,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
 
   /// @dev Retrieves the release manifest URI from the package db.
   /// @param releaseHash The release hash to retrieve the URI from.
-  function getManifestURI(bytes32 releaseHash)
+  function getReleaseManifestURI(bytes32 releaseHash)
     internal
     view
     returns (string)

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -42,7 +42,7 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseManifestURI The URI for the release manifest for this release.
+  /// @param manifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32 major,
@@ -50,7 +50,7 @@ contract PackageIndexInterface is AuthorizedInterface {
     uint32 patch,
     string preRelease,
     string build,
-    string releaseManifestURI
+    string manifestURI
   )
     public
     returns (bool);
@@ -129,7 +129,7 @@ contract PackageIndexInterface is AuthorizedInterface {
       uint32 patch,
       string preRelease,
       string build,
-      string releaseManifestURI,
+      string manifestURI,
       uint createdAt,
       uint updatedAt
     );
@@ -177,7 +177,7 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getReleaseManifestURI(
+  function getManifestURI(
     string name,
     uint32 major,
     uint32 minor,

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -177,7 +177,7 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getManifestURI(
+  function getReleaseManifestURI(
     string name,
     uint32 major,
     uint32 minor,

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -42,7 +42,7 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  /// @param releaseLockfileURI The URI for the release lockfile for this release.
+  /// @param releaseManifestURI The URI for the release manifest for this release.
   function release(
     string name,
     uint32 major,
@@ -50,7 +50,7 @@ contract PackageIndexInterface is AuthorizedInterface {
     uint32 patch,
     string preRelease,
     string build,
-    string releaseLockfileURI
+    string releaseManifestURI
   )
     public
     returns (bool);
@@ -129,7 +129,7 @@ contract PackageIndexInterface is AuthorizedInterface {
       uint32 patch,
       string preRelease,
       string build,
-      string releaseLockfileURI,
+      string releaseManifestURI,
       uint createdAt,
       uint updatedAt
     );
@@ -170,14 +170,14 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param numReleases The length of the slice
   function getReleaseHashes(uint offset, uint numReleases) public view returns (bytes32[]);
 
-  /// @dev Returns the release lockfile for the given release data
+  /// @dev Returns the release manifest for the given release data
   /// @param name Package name
   /// @param major The major portion of the semver version string.
   /// @param minor The minor portion of the semver version string.
   /// @param patch The patch portion of the semver version string.
   /// @param preRelease The pre-release portion of the semver version string.  Use empty string if the version string has no pre-release portion.
   /// @param build The build portion of the semver version string.  Use empty string if the version string has no build portion.
-  function getReleaseLockfileURI(
+  function getReleaseManifestURI(
     string name,
     uint32 major,
     uint32 minor,

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -18,7 +18,7 @@ contract ReleaseDB is Authorized {
     uint updatedAt;
     bytes32 nameHash;
     bytes32 versionHash;
-    string releaseLockfileURI;
+    string releaseManifestURI;
   }
 
   // Release Data: (releaseHash => value)
@@ -72,11 +72,11 @@ contract ReleaseDB is Authorized {
   /// @dev Creates or updates a release for a package.  Returns success.
   /// @param nameHash The name hash of the package.
   /// @param versionHash The version hash for the release version.
-  /// @param releaseLockfileURI The URI for the release lockfile for this release.
+  /// @param releaseManifestURI The URI for the release manifest for this release.
   function setRelease(
     bytes32 nameHash,
     bytes32 versionHash,
-    string releaseLockfileURI
+    string releaseManifestURI
   )
     public
     auth
@@ -107,8 +107,8 @@ contract ReleaseDB is Authorized {
     // Record the last time the release was updated.
     release.updatedAt = block.timestamp; // solium-disable-line security/no-block-members
 
-    // Save the release lockfile URI
-    release.releaseLockfileURI = releaseLockfileURI;
+    // Save the release manifest URI
+    release.releaseManifestURI = releaseManifestURI;
 
     // Track latest released versions for each branch of the release tree.
     updateLatestTree(releaseHash);
@@ -323,15 +323,15 @@ contract ReleaseDB is Authorized {
     return _recordedVersions[_recordedReleases[releaseHash].versionHash].build;
   }
 
-  /// @dev Returns the URI of the release lockfile for the given release hash.
+  /// @dev Returns the URI of the release manifest for the given release hash.
   /// @param releaseHash Release hash
-  function getReleaseLockfileURI(bytes32 releaseHash)
+  function getReleaseManifestURI(bytes32 releaseHash)
     public
     view
     onlyIfReleaseExists(releaseHash)
     returns (string)
   {
-    return _recordedReleases[releaseHash].releaseLockfileURI;
+    return _recordedReleases[releaseHash].releaseManifestURI;
   }
 
   /*

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -18,7 +18,7 @@ contract ReleaseDB is Authorized {
     uint updatedAt;
     bytes32 nameHash;
     bytes32 versionHash;
-    string releaseManifestURI;
+    string manifestURI;
   }
 
   // Release Data: (releaseHash => value)
@@ -72,11 +72,11 @@ contract ReleaseDB is Authorized {
   /// @dev Creates or updates a release for a package.  Returns success.
   /// @param nameHash The name hash of the package.
   /// @param versionHash The version hash for the release version.
-  /// @param releaseManifestURI The URI for the release manifest for this release.
+  /// @param manifestURI The URI for the release manifest for this release.
   function setRelease(
     bytes32 nameHash,
     bytes32 versionHash,
-    string releaseManifestURI
+    string manifestURI
   )
     public
     auth
@@ -108,7 +108,7 @@ contract ReleaseDB is Authorized {
     release.updatedAt = block.timestamp; // solium-disable-line security/no-block-members
 
     // Save the release manifest URI
-    release.releaseManifestURI = releaseManifestURI;
+    release.manifestURI = manifestURI;
 
     // Track latest released versions for each branch of the release tree.
     updateLatestTree(releaseHash);
@@ -325,13 +325,13 @@ contract ReleaseDB is Authorized {
 
   /// @dev Returns the URI of the release manifest for the given release hash.
   /// @param releaseHash Release hash
-  function getReleaseManifestURI(bytes32 releaseHash)
+  function getManifestURI(bytes32 releaseHash)
     public
     view
     onlyIfReleaseExists(releaseHash)
     returns (string)
   {
-    return _recordedReleases[releaseHash].releaseManifestURI;
+    return _recordedReleases[releaseHash].manifestURI;
   }
 
   /*

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -15,7 +15,7 @@ contract ReleaseValidator {
   /// @param majorMinorPatch The major/minor/patch portion of the version string.
   /// @param preRelease The pre-release portion of the version string.
   /// @param build The build portion of the version string.
-  /// @param releaseManifestURI The URI of the release manifest.
+  /// @param manifestURI The URI of the release manifest.
   function validateRelease(
     PackageDB packageDb,
     ReleaseDB releaseDb,
@@ -24,7 +24,7 @@ contract ReleaseValidator {
     uint32[3] majorMinorPatch,
     string preRelease,
     string build,
-    string releaseManifestURI
+    string manifestURI
   )
     public
     view
@@ -45,7 +45,7 @@ contract ReleaseValidator {
     } else if (!validatePackageName(packageDb, name)) {
       // invalid package name.
       revert("escape:ReleaseValidator:invalid-package-name");
-    } else if (!validateReleaseManifestURI(releaseManifestURI)) {
+    } else if (!validateManifestURI(manifestURI)) {
       // disallow empty release manifest URI
       revert("escape:ReleaseValidator:invalid-manifest-uri");
     } else if (!validateReleaseVersion(majorMinorPatch)) {
@@ -146,13 +146,13 @@ contract ReleaseValidator {
   }
 
   /// @dev Returns boolean whether the provided release manifest URI is valid.
-  /// @param releaseManifestURI The URI for a release manifest.
-  function validateReleaseManifestURI(string releaseManifestURI)
+  /// @param manifestURI The URI for a release manifest.
+  function validateManifestURI(string manifestURI)
     public
     pure
     returns (bool)
   {
-    if (bytes(releaseManifestURI).length == 0) {
+    if (bytes(manifestURI).length == 0) {
       return false;
     }
     return true;

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -15,7 +15,7 @@ contract ReleaseValidator {
   /// @param majorMinorPatch The major/minor/patch portion of the version string.
   /// @param preRelease The pre-release portion of the version string.
   /// @param build The build portion of the version string.
-  /// @param releaseLockfileURI The URI of the release lockfile.
+  /// @param releaseManifestURI The URI of the release manifest.
   function validateRelease(
     PackageDB packageDb,
     ReleaseDB releaseDb,
@@ -24,7 +24,7 @@ contract ReleaseValidator {
     uint32[3] majorMinorPatch,
     string preRelease,
     string build,
-    string releaseLockfileURI
+    string releaseManifestURI
   )
     public
     view
@@ -45,9 +45,9 @@ contract ReleaseValidator {
     } else if (!validatePackageName(packageDb, name)) {
       // invalid package name.
       revert("escape:ReleaseValidator:invalid-package-name");
-    } else if (!validateReleaseLockfileURI(releaseLockfileURI)) {
-      // disallow empty release lockfile URI
-      revert("escape:ReleaseValidator:invalid-lockfile-uri");
+    } else if (!validateReleaseManifestURI(releaseManifestURI)) {
+      // disallow empty release manifest URI
+      revert("escape:ReleaseValidator:invalid-manifest-uri");
     } else if (!validateReleaseVersion(majorMinorPatch)) {
       // disallow version 0.0.0
       revert("escape:ReleaseValidator:invalid-release-version");
@@ -145,14 +145,14 @@ contract ReleaseValidator {
     return true;
   }
 
-  /// @dev Returns boolean whether the provided release lockfile URI is valid.
-  /// @param releaseLockfileURI The URI for a release lockfile.
-  function validateReleaseLockfileURI(string releaseLockfileURI)
+  /// @dev Returns boolean whether the provided release manifest URI is valid.
+  /// @param releaseManifestURI The URI for a release manifest.
+  function validateReleaseManifestURI(string releaseManifestURI)
     public
     pure
     returns (bool)
   {
-    if (bytes(releaseLockfileURI).length == 0) {
+    if (bytes(releaseManifestURI).length == 0) {
       return false;
     }
     return true;

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -251,7 +251,7 @@ contract('PackageIndex', function(accounts){
         const releaseHash = await releaseDB.hashRelease(nameHash, versionHash)
 
         await packageIndex.release(...releaseInfo)
-        const manifestUri = await packageIndex.getManifestURI(...releaseInfo.slice(0, -1))
+        const manifestUri = await packageIndex.getReleaseManifestURI(...releaseInfo.slice(0, -1))
         assert(manifestUri === releaseInfo.pop())
       });
 

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -49,7 +49,7 @@ contract('PackageIndex', function(accounts){
     assert( releaseData.patch.toNumber() === patch );
     assert( releaseData.preRelease === preRelease );
     assert( releaseData.build === build );
-    assert( releaseData.releaseManifestURI === manifestUri );
+    assert( releaseData.manifestURI === manifestUri );
     assert( releaseData.createdAt.toNumber() === timestamp );
     assert( releaseData.updatedAt.toNumber() === timestamp );
   }
@@ -251,7 +251,7 @@ contract('PackageIndex', function(accounts){
         const releaseHash = await releaseDB.hashRelease(nameHash, versionHash)
 
         await packageIndex.release(...releaseInfo)
-        const manifestUri = await packageIndex.getReleaseManifestURI(...releaseInfo.slice(0, -1))
+        const manifestUri = await packageIndex.getManifestURI(...releaseInfo.slice(0, -1))
         assert(manifestUri === releaseInfo.pop())
       });
 

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -28,7 +28,7 @@ contract('PackageIndex', function(accounts){
     patch,
     preRelease,
     build,
-    lockfileUri,
+    manifestUri,
     receipt,
     releaseData,
   ){
@@ -49,7 +49,7 @@ contract('PackageIndex', function(accounts){
     assert( releaseData.patch.toNumber() === patch );
     assert( releaseData.preRelease === preRelease );
     assert( releaseData.build === build );
-    assert( releaseData.releaseLockfileURI === lockfileUri );
+    assert( releaseData.releaseManifestURI === manifestUri );
     assert( releaseData.createdAt.toNumber() === timestamp );
     assert( releaseData.updatedAt.toNumber() === timestamp );
   }
@@ -244,15 +244,15 @@ contract('PackageIndex', function(accounts){
         assert( actualReleaseHashB == releaseHashB )
       })
 
-      it('should retrieve the lockfile Uri', async function(){
+      it('should retrieve the manifest Uri', async function(){
         const releaseInfo = ['test', 2, 3, 4, 'c', 'e', 'ipfs://some--ipfs-uri']
 
         const versionHash = await releaseDB.hashVersion(...releaseInfo.slice(1, -1))
         const releaseHash = await releaseDB.hashRelease(nameHash, versionHash)
 
         await packageIndex.release(...releaseInfo)
-        const lockfileUri = await packageIndex.getReleaseLockfileURI(...releaseInfo.slice(0, -1))
-        assert(lockfileUri === releaseInfo.pop())
+        const manifestUri = await packageIndex.getReleaseManifestURI(...releaseInfo.slice(0, -1))
+        assert(manifestUri === releaseInfo.pop())
       });
 
       it('should retrieve release by release hash', async function(){

--- a/test/releaseDB.js
+++ b/test/releaseDB.js
@@ -378,7 +378,7 @@ contract('ReleaseDB', function(accounts){
 
       const numReleases = await releaseDB.getNumReleasesForNameHash(nameHash);
       assert( numReleases.toNumber() === 12 );
-      assert( await releaseDB.getReleaseManifestURI(v124h) === newUri );
+      assert( await releaseDB.getManifestURI(v124h) === newUri );
 
       const events = await releaseDB.getPastEvents('ReleaseUpdate', {fromBlock: 0, toBlock: 'latest'});
       assert(events.length === 1);
@@ -557,7 +557,7 @@ contract('ReleaseDB', function(accounts){
 
       assert( await releaseDB.getPreRelease(releaseHash) === 'beta.1' )
       assert( await releaseDB.getBuild(releaseHash) === 'build.abcd1234' )
-      assert( await releaseDB.getReleaseManifestURI(releaseHash) == 'ipfs://some-ipfs-uri' )
+      assert( await releaseDB.getManifestURI(releaseHash) == 'ipfs://some-ipfs-uri' )
 
       const majorMinorPatch = await releaseDB.getMajorMinorPatch(versionHash);
 

--- a/test/releaseDB.js
+++ b/test/releaseDB.js
@@ -378,7 +378,7 @@ contract('ReleaseDB', function(accounts){
 
       const numReleases = await releaseDB.getNumReleasesForNameHash(nameHash);
       assert( numReleases.toNumber() === 12 );
-      assert( await releaseDB.getReleaseLockfileURI(v124h) === newUri );
+      assert( await releaseDB.getReleaseManifestURI(v124h) === newUri );
 
       const events = await releaseDB.getPastEvents('ReleaseUpdate', {fromBlock: 0, toBlock: 'latest'});
       assert(events.length === 1);
@@ -557,7 +557,7 @@ contract('ReleaseDB', function(accounts){
 
       assert( await releaseDB.getPreRelease(releaseHash) === 'beta.1' )
       assert( await releaseDB.getBuild(releaseHash) === 'build.abcd1234' )
-      assert( await releaseDB.getReleaseLockfileURI(releaseHash) == 'ipfs://some-ipfs-uri' )
+      assert( await releaseDB.getReleaseManifestURI(releaseHash) == 'ipfs://some-ipfs-uri' )
 
       const majorMinorPatch = await releaseDB.getMajorMinorPatch(versionHash);
 

--- a/test/releaseValidator.js
+++ b/test/releaseValidator.js
@@ -59,7 +59,7 @@ contract('ReleaseValidator', function(accounts){
       let releaseData = await packageIndex.getReleaseData(releaseHash);
 
       assert(packageData.numReleases.toNumber() === 1);
-      assert(releaseData.releaseLockfileURI === uri)
+      assert(releaseData.releaseManifestURI === uri)
 
       info.pop();
       info.push(otherUri);
@@ -73,7 +73,7 @@ contract('ReleaseValidator', function(accounts){
       releaseData = await packageIndex.getReleaseData(releaseHash);
 
       assert(packageData.numReleases.toNumber() === 1);
-      assert(releaseData.releaseLockfileURI === uri);
+      assert(releaseData.releaseManifestURI === uri);
     };
 
     const uri = 'ipfs://some-ipfs-uri';
@@ -514,16 +514,16 @@ contract('ReleaseValidator', function(accounts){
     });
   });
 
-  describe('Lockfile', function(){
+  describe('Manifest', function(){
 
-    it('does not allow an empty lockfile', async function(){
+    it('does not allow an empty manifestURI field', async function(){
       const info = ['test', 1, 0, 0, '', '', ''];
 
       assert( await packageIndex.packageExists('test') === false );
 
       await assertFailure(
         packageIndex.release(...info),
-        'invalid-lockfile-uri'
+        'invalid-manifest-uri'
       );
 
       assert( await packageIndex.packageExists('test') === false );

--- a/test/releaseValidator.js
+++ b/test/releaseValidator.js
@@ -59,7 +59,7 @@ contract('ReleaseValidator', function(accounts){
       let releaseData = await packageIndex.getReleaseData(releaseHash);
 
       assert(packageData.numReleases.toNumber() === 1);
-      assert(releaseData.releaseManifestURI === uri)
+      assert(releaseData.manifestURI === uri)
 
       info.pop();
       info.push(otherUri);
@@ -73,7 +73,7 @@ contract('ReleaseValidator', function(accounts){
       releaseData = await packageIndex.getReleaseData(releaseHash);
 
       assert(packageData.numReleases.toNumber() === 1);
-      assert(releaseData.releaseManifestURI === uri);
+      assert(releaseData.manifestURI === uri);
     };
 
     const uri = 'ipfs://some-ipfs-uri';


### PR DESCRIPTION
#43 

Updates all references to 'lockfile' following the name change in EthPM V2 spec implemented [here](https://github.com/ethpm/ethpm-spec/pull/86/files).

NB: in the PR at ethpm-spec linked to above  `lockfile` is replaced by the word `package` in most cases. Preferring for the word `manifest` as a substitution here because it seems reasonably clear in context but maybe this should be discussed. . . 
