### PR TITLE
Prevent re-publication at version of a previously removed release

### DIFF
--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -23,6 +23,7 @@ contract ReleaseDB is Authorized {
 
   // Release Data: (releaseHash => value)
   mapping (bytes32 => Release) _recordedReleases;
+  mapping (bytes32 => bool) _removedReleases;
   IndexedOrderedSetLib.IndexedOrderedSet _allReleaseHashes;
   mapping (bytes32 => IndexedOrderedSetLib.IndexedOrderedSet) _releaseHashesByNameHash;
 
@@ -160,6 +161,9 @@ contract ReleaseDB is Authorized {
     _allReleaseHashes.remove(releaseHash);
     _releaseHashesByNameHash[nameHash].remove(releaseHash);
 
+    // Add the release hash to the map of removed releases
+    _removedReleases[releaseHash] = true;
+
     // Log the removal.
     emit ReleaseDelete(releaseHash, reason);
 
@@ -260,6 +264,16 @@ contract ReleaseDB is Authorized {
     returns (bool)
   {
     return _recordedReleases[releaseHash].exists;
+  }
+
+  /// @dev Query the past existence of a release at the provided version for a package.  Returns boolean indicating whether such a release ever existed.
+  /// @param releaseHash The release hash to query.
+  function releaseExisted(bytes32 releaseHash)
+    public
+    view
+    returns (bool)
+  {
+    return _removedReleases[releaseHash];
   }
 
   /// @dev Query the existence of the provided version in the recorded versions.  Returns boolean indicating whether such a version exists.

--- a/contracts/ReleaseValidator.sol
+++ b/contracts/ReleaseValidator.sol
@@ -41,7 +41,7 @@ contract ReleaseValidator {
       revert("escape:ReleaseValidator:caller-not-authorized");
     } else if (!validateIsNewRelease(packageDb, releaseDb, name, majorMinorPatch, preRelease, build)) {
       // this version has already been released.
-      revert("escape:ReleaseValidator:version-exists");
+      revert("escape:ReleaseValidator:version-previously-published");
     } else if (!validatePackageName(packageDb, name)) {
       // invalid package name.
       revert("escape:ReleaseValidator:invalid-package-name");
@@ -104,7 +104,7 @@ contract ReleaseValidator {
     bytes32 nameHash = packageDb.hashName(name);
     bytes32 versionHash = releaseDb.hashVersion(majorMinorPatch[0], majorMinorPatch[1], majorMinorPatch[2], preRelease, build);
     bytes32 releaseHash = releaseDb.hashRelease(nameHash, versionHash);
-    return !releaseDb.releaseExists(releaseHash);
+    return !releaseDb.releaseExists(releaseHash) && !releaseDb.releaseExisted(releaseHash);
   }
 
   uint constant DIGIT_0 = uint(bytes1("0"));


### PR DESCRIPTION
#32

+ Adds a mapping to ReleaseDB that tracks whether a release hash has ever been removed and prevents a package owner from publishing at that tag again. 
+ Adds a test at `releaseValidator` to validate new behavior
+ Modifies the message for re-publishing error from `version-exists` to `version-previously-published`

Important to note that the PackageIndex owner is still free to set a release at a removed version. They call also remove releases and re-assign the manifestURI for a release so we have a very 'npm-like' registry where there are different levels of privilege and admins can control what's in the DB.

One feature npm has that this registry doesn't is the ability for package owners to un-publish packages themselves. At the moment they would need to ask someone to do that for them. 

