### PR TITLE
Add new package and release ID getters (per EIP)

### DIFF
--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -171,10 +171,9 @@ contract PackageDB is Authorized {
     return _recordedPackages[nameHash].name;
   }
 
-  /// @dev Returns `limit` number of package ids at starting from `index` offset
-  /// @param _offset  index to begin retrieving names from. First request should use zero,
-  ///                 subsequent requests should use the returned offset value
-  /// @param limit    number of ids to return
+  /// @dev Returns a slice of the array of all package hashes for the named package.
+  /// @param offset The starting index for the slice.
+  /// @param limit  The length of the slice
   function getAllPackageIds(uint _offset, uint limit)
     public
     view
@@ -183,7 +182,7 @@ contract PackageDB is Authorized {
       uint offset
     )
   {
-    bytes32[] memory hashes;                 // Array of package names to return
+    bytes32[] memory hashes;                 // Array of package ids to return
     uint cursor = _offset;                   // Index counter to traverse DB array
     uint remaining;                          // Counter to collect `limit` packages
     uint totalPackages = getNumPackages();   // Total number of packages in registry

--- a/contracts/PackageDB.sol
+++ b/contracts/PackageDB.sol
@@ -201,15 +201,11 @@ contract PackageDB is Authorized {
       // Allocate return array
       hashes = new bytes32[](remaining);
 
-      // Collect records, skipping deleted entries
-      // in the IndexedOrderedSet mapping.
+      // Collect records. (IndexedOrderedSet manages deletions.)
       while(remaining > 0){
         bytes32 hash = getPackageNameHash(cursor);
-
-        if (packageExists(hash)){
-          hashes[remaining - 1] = hash;
-          remaining--;
-        }
+        hashes[remaining - 1] = hash;
+        remaining--;
         cursor++;
       }
     }

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -352,41 +352,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     return releaseDb.getAllReleaseHashes(nameHash, _offset, limit);
   }
 
-  /// @dev Returns an array of all release hashes for the named package.
-  /// @param name Package name
-  function getAllPackageReleaseHashes(string name)
-    public
-    view
-    returns (bytes32[])
-  {
-    uint numReleases;
-    (,,numReleases,) = getPackageData(name);
-    return getPackageReleaseHashes(name, 0, numReleases);
-  }
-
-  /// @dev Returns a slice of the array of all release hashes for the named package.
-  /// @param name Package name
-  /// @param offset The starting index for the slice.
-  /// @param numReleases The length of the slice
-  function getPackageReleaseHashes(
-    string name,
-    uint offset,
-    uint numReleases
-  )
-    public
-    view
-    returns (bytes32[])
-  {
-    bytes32 nameHash = packageDb.hashName(name);
-    bytes32[] memory releaseHashes = new bytes32[](numReleases);
-
-    for (uint i = offset; i < offset + numReleases; i++) {
-      releaseHashes[i] = releaseDb.getReleaseHashForNameHash(nameHash, i);
-    }
-
-    return releaseHashes;
-  }
-
+  /// @dev Returns total number of releases in the registry
   function getNumReleases()
     public
     view

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -263,6 +263,20 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     return packageDb.getNumPackages();
   }
 
+  /// @dev Returns a slice of the array of all package hashes for the named package.
+  /// @param _offset The starting index for the slice.
+  /// @param limit  The length of the slice
+  function getAllPackageIds(uint _offset, uint limit)
+    public
+    view
+    returns(
+      bytes32[] packageIds,
+      uint offset
+    )
+  {
+    return packageDb.getAllPackageIds(_offset, limit);
+  }
+
   /// @dev Returns the name of the package at the provided index
   /// @param idx The index of the name hash to lookup.
   function getPackageName(uint idx)
@@ -271,6 +285,16 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     returns (string)
   {
     return getPackageName(packageDb.getPackageNameHash(idx));
+  }
+
+  /// @dev Retrieves the name for the given name hash.
+  /// @param nameHash The name hash to lookup the name for.
+  function getPackageName(bytes32 nameHash)
+    public
+    view
+    returns (string)
+  {
+    return PackageDB(packageDb).getPackageName(nameHash);
   }
 
   /// @dev Returns the package data.
@@ -428,16 +452,6 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     address packageOwner;
     (packageOwner,,,) = getPackageData(name);
     return (packageOwner != _address);
-  }
-
-  /// @dev Retrieves the name for the given name hash.
-  /// @param nameHash The name hash to lookup the name for.
-  function getPackageName(bytes32 nameHash)
-    internal
-    view
-    returns (string)
-  {
-    return PackageDB(packageDb).getPackageName(nameHash);
   }
 
   /// @dev Retrieves the release manifest URI from the package db.

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -362,8 +362,9 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     return releaseDb.getReleaseHashForNameHash(nameHash, releaseIdx);
   }
 
-  /// @dev Returns an array of all release hashes for the named package.
-  /// @param name     Package name
+  /// @dev Returns a slice of the array of all package hashes for the named package.
+  /// @param offset The starting index for the slice.
+  /// @param limit  The length of the slice
   function getAllReleaseIds(string name, uint _offset, uint limit)
     public
     view
@@ -373,7 +374,7 @@ contract PackageIndex is Authorized, PackageIndexInterface {
     )
   {
     bytes32 nameHash = packageDb.hashName(name);
-    return releaseDb.getAllReleaseHashes(nameHash, _offset, limit);
+    return releaseDb.getAllReleaseIds(nameHash, _offset, limit);
   }
 
   /// @dev Returns total number of releases in the registry

--- a/contracts/PackageIndex.sol
+++ b/contracts/PackageIndex.sol
@@ -339,6 +339,20 @@ contract PackageIndex is Authorized, PackageIndexInterface {
   }
 
   /// @dev Returns an array of all release hashes for the named package.
+  /// @param name     Package name
+  function getAllReleaseIds(string name, uint _offset, uint limit)
+    public
+    view
+    returns (
+      bytes32[] releaseIds,
+      uint offset
+    )
+  {
+    bytes32 nameHash = packageDb.hashName(name);
+    return releaseDb.getAllReleaseHashes(nameHash, _offset, limit);
+  }
+
+  /// @dev Returns an array of all release hashes for the named package.
   /// @param name Package name
   function getAllPackageReleaseHashes(string name)
     public

--- a/contracts/PackageIndexInterface.sol
+++ b/contracts/PackageIndexInterface.sol
@@ -106,6 +106,15 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param idx The index of the name hash to lookup.
   function getPackageName(uint idx) public view returns (string);
 
+  /// @dev Returns the name of the package at the provided index
+  /// @param releaseId The index of the name hash to lookup.
+  function getPackageName(bytes32 releaseId) public view returns (string);
+
+  /// @dev Returns a slice of the array of all package hashes for the named package.
+  /// @param offset The starting index for the slice.
+  /// @param limit  The length of the slice
+  function getAllPackageIds(uint offset, uint limit) public view returns (bytes32[], uint);
+
   /// @dev Returns the package data.
   /// @param name Package name
   function getPackageData(string name)
@@ -143,22 +152,11 @@ contract PackageIndexInterface is AuthorizedInterface {
   /// @param releaseIdx The index of the release to retrieve.
   function getReleaseHashForPackage(string name, uint releaseIdx) public view returns (bytes32);
 
-  /// @dev Returns an array of all release hashes for the named package.
-  /// @param name Package name
-  function getAllPackageReleaseHashes(string name) public view returns (bytes32[]);
-
   /// @dev Returns a slice of the array of all release hashes for the named package.
   /// @param name Package name
   /// @param offset The starting index for the slice.
-  /// @param numReleases The length of the slice
-  function getPackageReleaseHashes(
-    string name,
-    uint offset,
-    uint numReleases
-  )
-    public
-    view
-    returns (bytes32[]);
+  /// @param limit  The length of the slice
+  function getAllReleaseIds(string name, uint offset, uint limit) public view returns (bytes32[], uint);
 
   function getNumReleases() public view returns (uint);
 

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -261,14 +261,11 @@ contract ReleaseDB is Authorized {
       // Allocate return array
       hashes = new bytes32[](remaining);
 
-      // Collect records, skipping deleted entries
+      // Collect records. (IndexedOrderedSet manages deletions.)
       while(remaining > 0){
         bytes32 hash = getReleaseHashForNameHash(nameHash, cursor);
-
-        if (releaseExists(hash)){
-          hashes[remaining - 1] = hash;
-          remaining--;
-        }
+        hashes[remaining - 1] = hash;
+        remaining--;
         cursor++;
       }
     }

--- a/contracts/ReleaseDB.sol
+++ b/contracts/ReleaseDB.sol
@@ -231,12 +231,10 @@ contract ReleaseDB is Authorized {
     return _allReleaseHashes.get(idx);
   }
 
-  /// @dev Returns `limit` number of release hashes starting from `index` offset
-  /// @param nameHash hash of name of package being queried
-  /// @param _offset  index to begin retrieving names from. First request should use zero,
-  ///                 subsequent requests should use the returned offset value
-  /// @param limit    number of ids to return
-  function getAllReleaseHashes(bytes32 nameHash, uint _offset, uint limit)
+  /// @dev Returns a slice of the array of all releases hashes for the named package.
+  /// @param offset The starting index for the slice.
+  /// @param limit  The length of the slice
+  function getAllReleaseIds(bytes32 nameHash, uint _offset, uint limit)
     public
     view
     returns (
@@ -244,7 +242,7 @@ contract ReleaseDB is Authorized {
       uint offset
     )
   {
-    bytes32[] memory hashes;                                  // Release hashes to return
+    bytes32[] memory hashes;                                  // Release ids to return
     uint cursor = _offset;                                    // Index counter to traverse DB array
     uint remaining;                                           // Counter to collect `limit` packages
     uint totalReleases = getNumReleasesForNameHash(nameHash); // Total number of packages in registry

--- a/test/packageDB.js
+++ b/test/packageDB.js
@@ -133,4 +133,145 @@ contract('PackageDB', function(accounts){
       );
     });
   });
+
+  describe('getAllPackageIds', function(){
+    let packageNames = ['a','b','c','d','e'];
+    let packageHashes = [];
+
+    before(async ()=> {
+      for (let name of packageNames){
+        let hash = await packageDB.hashName(name);
+        packageHashes.push(hash);
+      }
+    })
+
+    beforeEach(async () => packageDB = await PackageDB.new());
+
+    it('returns ([],0) for an empty DB', async() => {
+      const result = await packageDB.getAllPackageIds(0,20);
+
+      assert(Array.isArray(result.packageIds));
+      assert(result.packageIds.length === 0);
+      assert(result.offset.toNumber() === 0)
+    });
+
+    it('returns ([],0) when limit param is zero', async()=> {
+      const result = await packageDB.getAllPackageIds(0,0);
+
+      assert(Array.isArray(result.packageIds));
+      assert(result.packageIds.length === 0);
+      assert(result.offset.toNumber() === 0)
+    });
+
+    it('returns ([],offset) when offset equals DB size', async()=>{
+      const dbSize = await packageDB.getNumPackages();
+      const offset = dbSize.toNumber();
+      const result = await packageDB.getAllPackageIds(offset,20);
+
+      assert(Array.isArray(result.packageIds));
+      assert(result.packageIds.length === 0);
+      assert(result.offset.toNumber() === offset)
+    });
+
+    it('returns ([allPackageIds], limit) when limit is greater than DB size', async()=>{
+      for (let name of packageNames){
+        await packageDB.setPackage(name);
+      }
+
+      const dbSize = await packageDB.getNumPackages();
+
+      assert(dbSize.toNumber() === packageNames.length);
+      const limit = dbSize.toNumber() + 1;
+      const result = await packageDB.getAllPackageIds(0,limit);
+
+      assert(result.packageIds.length === dbSize.toNumber());
+      assert(result.offset.toNumber() === dbSize.toNumber());
+
+      for(let hash of packageHashes){
+        assert(result.packageIds.includes(hash));
+      }
+    });
+
+    it('returns the correct number of packages and offset when limit is < DB size', async()=>{
+      for (let name of packageNames){
+        await packageDB.setPackage(name);
+      }
+
+      const limit = 3;
+      const firstPage = packageHashes.slice(0,limit);
+      const secondPage = packageHashes.slice(limit);
+      const dbSize = await packageDB.getNumPackages();
+
+      assert(limit < dbSize);
+
+      const resultA = await packageDB.getAllPackageIds(0,limit);
+
+      // Initial results (3)
+      assert(resultA.packageIds.length === limit);
+      assert(resultA.offset.toNumber() === limit);
+
+      const resultB = await packageDB.getAllPackageIds(resultA.offset, limit);
+
+      // Remaining results (2)
+      assert(resultB.packageIds.length === dbSize.toNumber() - limit);
+      assert(resultB.offset.toNumber() === dbSize.toNumber());
+
+      const resultC = await packageDB.getAllPackageIds(resultB.offset, limit);
+
+      // Empty results, terminal index
+      assert(resultC.packageIds.length === 0);
+      assert(resultC.offset.toNumber() === dbSize.toNumber());
+
+      // Verify that return results don't overlap
+      for (let hash in resultA.packageIds){
+        assert(!resultB.packageIds.includes(hash))
+      }
+    });
+
+    it('handles DBs with removed items correctly', async()=>{
+      for (let name of packageNames){
+        await packageDB.setPackage(name);
+      }
+
+      const limit = await packageDB.getNumPackages();
+
+      const hashToRemove = packageHashes[2];
+      await packageDB.removePackage(hashToRemove, 'because');
+
+      const resultA = await packageDB.getAllPackageIds(0,limit);
+
+      // Initial results (4)
+      assert(resultA.packageIds.length === limit - 1);
+      assert(resultA.offset.toNumber() === limit - 1);
+      assert(!resultA.packageIds.includes(hashToRemove));
+
+      const resultB = await packageDB.getAllPackageIds(resultA.offset, limit);
+
+      // Empty results, terminal index
+      assert(resultB.packageIds.length === 0);
+      assert(resultB.offset.toNumber() === resultA.offset.toNumber());
+    });
+
+    it('should be possible to extract all the package names', async()=> {
+      let names = [];
+
+      for (let name of packageNames){
+        await packageDB.setPackage(name);
+      }
+
+      const limit = await packageDB.getNumPackages();
+      const result = await packageDB.getAllPackageIds(0,limit);
+
+      assert(result.packageIds.length === packageNames.length);
+
+      for (let hash of result.packageIds){
+        let name = await packageDB.getPackageName(hash);
+        names.push(name);
+      }
+
+      for (let name of names ){
+        assert(packageNames.includes(name));
+      }
+    })
+  });
 });

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -380,7 +380,7 @@ contract('PackageIndex', function(accounts){
       })
     });
 
-    describe('getAllReleaseIds (normal cases)', function(){
+    describe('getAllReleaseIds', function(){
       let releaseHashA;
       let releaseHashB;
       let releaseHashC;
@@ -404,6 +404,37 @@ contract('PackageIndex', function(accounts){
         await packageIndex.release(...releaseInfoB)
         await packageIndex.release(...releaseInfoC)
       })
+
+      it('returns ([],0) for a non-existent release', async() => {
+        const limit = 20;
+        const result = await packageIndex.getAllReleaseIds('test-none', 0, limit);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 0);
+        assert(result.offset.toNumber() === 0)
+      });
+
+      it('returns ([],offset) when offset equals # of releases', async()=>{
+        const limit = 20;
+        const packageData = await packageIndex.getPackageData('test-r');
+        const numReleases = packageData.numReleases.toNumber();
+        assert(numReleases === 3 );
+
+        const offset = numReleases;
+        const result = await packageIndex.getAllReleaseIds('test-r', offset, limit);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 0);
+        assert(result.offset.toNumber() === offset)
+      });
+
+      it('returns ([],0) when limit param is zero', async()=> {
+        const result = await packageIndex.getAllReleaseIds('test-r',0,0);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 0);
+        assert(result.offset.toNumber() === 0)
+      });
 
       it('returns ([allReleaseIds], limit) when limit is greater than # of releases', async function(){
         const packageData = await packageIndex.getPackageData('test-r');

--- a/test/packageIndex.js
+++ b/test/packageIndex.js
@@ -275,35 +275,6 @@ contract('PackageIndex', function(accounts){
         await assertRelease(...releaseInfoB, responseB.receipt, releaseDataB)
       });
 
-      it('should retrieve a list of release hashes', async function(){
-        nameHash = await packageDB.hashName('test-r');
-
-        const releaseInfoA = ['test-r', 1, 2, 3, 't', 'u', 'ipfs://some-ipfs-uri']
-        const releaseInfoB = ['test-r', 2, 3, 4, 'v', 'y', 'ipfs://some-other-ipfs-uri']
-        const releaseInfoC = ['test-r', 3, 4, 5, 'w', 'q', 'ipfs://yet-another-ipfs-uri']
-
-        const versionHashA = await releaseDB.hashVersion(...releaseInfoA.slice(1, -1))
-        const versionHashB = await releaseDB.hashVersion(...releaseInfoB.slice(1, -1))
-        const versionHashC = await releaseDB.hashVersion(...releaseInfoC.slice(1, -1))
-
-        const releaseHashA = await releaseDB.hashRelease(nameHash, versionHashA)
-        const releaseHashB = await releaseDB.hashRelease(nameHash, versionHashB)
-        const releaseHashC = await releaseDB.hashRelease(nameHash, versionHashC)
-
-        await packageIndex.release(...releaseInfoA)
-        await packageIndex.release(...releaseInfoB)
-        await packageIndex.release(...releaseInfoC)
-
-        const packageData =  await packageIndex.getPackageData('test-r');
-        assert(packageData.numReleases.toNumber() === 3 );
-
-        const releaseHashes = await packageIndex.getAllPackageReleaseHashes('test-r');
-
-        assert(releaseHashes["0"] === releaseHashA);
-        assert(releaseHashes["1"] === releaseHashB);
-        assert(releaseHashes["2"] === releaseHashC);
-      });
-
       it('should retrieve a list of ALL release hashes', async function(){
         const nameHashA = await packageDB.hashName('test-a')
         const nameHashB = await packageDB.hashName('test-b')


### PR DESCRIPTION
Adds (to implementation and `PackageIndexInterface`:

+ `getAllPackageIds(uint offset, uint limit) public view returns (bytes32[], uint);`
+ `getPackageName(bytes32 packageId) public view returns (string)`;
+ `getAllReleaseIds(string name, uint offset, uint limit) public view returns (bytes32[], uint);`
+ removes `releaseHash` getters that implemented similar functionality.
+ unit tests for the above


