### PR TITLE
Upgrade truffle / Update README for ENS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,27 @@
 [![Coverage Status](https://coveralls.io/repos/github/ethpm/escape-truffle/badge.svg?branch=master)](https://coveralls.io/github/ethpm/escape-truffle?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/ethpm-package-registry/badge/?version=latest)](https://ethpm-package-registry.readthedocs.io/en/latest/?badge=latest)
 
-### Install
+## Install
 ```
 $ npm install
 $ docker pull ethereum/client-go:v1.8.6 # Optional
 ```
 
-### Test
+## Test
 ```
 $ npm test        # vs. ganache-cli
 $ npm test:geth   # vs. geth
 ```
 
-### Deploy
+## Deploy
 
 This repository contains deployment scripts that let you quickly publish
 your own package registry to a public testnet and authorize your account
-address as its owner. There's also a script that lets you register a temporary ENS
+address as its owner. There's also a small wizard that helps you register a temporary ENS
 namespace for your Ropsten deployed registry so users and tooling can easily reference it when
 requesting a package.
 
-**Configuration**
+### Configuration
 
 Clone the repo and create a `.secrets.js` file in the project root that looks like this:
 
@@ -33,8 +33,8 @@ Clone the repo and create a `.secrets.js` file in the project root that looks li
 module.exports = {
   ropsten: {
     mnemonic: 'use your own twelve word mnemonic here do not use this one',
-    infura: "F6tUooiW4thx777DtPsa" // <-- Example Infura API key.
-    ENSName: "my-registry.test"  // Example ENS name
+    infura: "F6tUooiW4thx777DtPsa" // Example Infura API key.
+    ENSName: "my-registry.test"    // Example ENS name (must use .test postfix)
   },
   rinkeby: {
     ..etc..
@@ -45,16 +45,17 @@ module.exports = {
 + Infura API keys are available [here](https://infura.io/register)
 + A 12 word mnemonic (for testing purposes only) can be generated [here](iancoleman.io/bip39)
 
-**Deployment**
+
+#### Deployment
 
 At the command line run:
 ```shell
 $ npm run deploy:ropsten
 ```
 
-**Temporary ENS Name Registration**
+#### Temporary ENS Name Registration
 
-After deploying a regisry to Ropsten, and setting an ENSName value under the Ropsten key in your
+After deploying a regisry to Ropsten, and setting an `ENSName` value under the `ropsten` key in your
 secrets file, run:
 
 ```shell
@@ -63,20 +64,19 @@ $ npm run ens:register
 
 The name will resolve to your registry's contract address and be valid for 28 days.
 
-
-### Coverage
+## Coverage
 ```
 $ npm run coverage
 ```
 
-### Lint
+## Lint
 
 For help, see the [Solium documentation](https://github.com/duaraghav8/Solium)
 ```
 $ npm run lint
 ```
 
-### Docs
+## Docs
 
 Docs are automatically built & published to ReadTheDocs on merge at
 [EthPM Package Registry](https://ethpm-package-registry.readthedocs.io/en/latest/).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Install
 ```
 $ npm install
-$ docker pull ethereum/client-go:v1.8.6
+$ docker pull ethereum/client-go:v1.8.6 # Optional
 ```
 
 ### Test
@@ -21,29 +21,47 @@ $ npm test:geth   # vs. geth
 
 This repository contains deployment scripts that let you quickly publish
 your own package registry to a public testnet and authorize your account
-address as its owner.
+address as its owner. There's also a script that lets you register a temporary ENS
+namespace for your Ropsten deployed registry so users and tooling can easily reference it when
+requesting a package.
+
+**Configuration**
 
 Clone the repo and create a `.secrets.js` file in the project root that looks like this:
 
 ```javascript
 module.exports = {
-    ropsten: {
-      mnemonic: 'use your own twelve word mnemonic here do not use this one',
-      infura: "F6tUooiW4thx777DtPsa" // <-- Example Infura API key.
-    },
-    rinkeby: {
-      ..etc..
-    }
+  ropsten: {
+    mnemonic: 'use your own twelve word mnemonic here do not use this one',
+    infura: "F6tUooiW4thx777DtPsa" // <-- Example Infura API key.
+    ENSName: "my-registry.test"  // Example ENS name
+  },
+  rinkeby: {
+    ..etc..
+  }
 }
 ```
+
++ Infura API keys are available [here](https://infura.io/register)
++ A 12 word mnemonic (for testing purposes only) can be generated [here](iancoleman.io/bip39)
+
+**Deployment**
 
 At the command line run:
 ```shell
 $ npm run deploy:ropsten
 ```
 
-+ Infura API keys are available [here](https://infura.io/register)
-+ A 12 word mnemonic (for testing purposes only) can be generated [here](iancoleman.io/bip39)
+**Temporary ENS Name Registration**
+
+After deploying a regisry to Ropsten, and setting an ENSName value under the Ropsten key in your
+secrets file, run:
+
+```shell
+$ npm run ens:register
+```
+
+The name will resolve to your registry's contract address and be valid for 28 days.
 
 
 ### Coverage

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "shelljs": "^0.8.1",
     "solidity-coverage": "^0.5.0",
     "solium": "^1.1.7",
-    "truffle": "5.0.0-next.6"
+    "truffle": "5.0.0-next.9"
   },
   "dependencies": {
     "colors": "^1.3.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -19,7 +19,7 @@ module.exports = {
       await promise;
       assert.fail();
     } catch(err){
-      assert(err.receipt && parseInt(err.receipt.status) === 0);
+      assert(err.receipt && !err.receipt.status);
 
       if (err.reason){
         assert(err.reason.includes(reason), `Expected reason: "${err.reason}"`);


### PR DESCRIPTION
Maintenance:

+ Updates truffle (which now uses web3 beta.35) and fixes the test helper which checks receipt status.
+ Add info about ENS name registration script to README 