### PR TITLE
Fix secondary CI jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/ethpm/escape-truffle#readme",
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "eth-gas-reporter": "^0.1.7",
+    "eth-gas-reporter": "0.1.7",
     "ganache-cli": "6.1.6",
     "shelljs": "^0.8.1",
     "solidity-coverage": "^0.5.0",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -49,6 +49,7 @@ start_client() {
       --dev \
       --dev.period 1 \
       --targetgaslimit '8000000' \
+      --allow-insecure-unlock \
       js ./scripts/geth-accounts.js \
       > /dev/null &
 


### PR DESCRIPTION
#57 

+ Pins gas-reporter to last working version.
+ Adds a ([now necessary](https://ethereum.stackexchange.com/questions/69435/error-account-unlock-with-http-access-is-forbidden-when-unlock-an-account-in-ge)) flag to the geth launch so the script which funds and unlocks multiple accounts will work.
